### PR TITLE
Tell minizip to use 32-bit API on most statically-linked consoles.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,11 +52,6 @@ include:
     file: '/ios9.yml'
 
   ################################## CONSOLES ################################
-
-  # PlayStation Portable
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/psp-static.yml'
-
   # PlayStation Vita
   - project: 'libretro-infrastructure/ci-templates'
     file: '/vita-static.yml'
@@ -76,10 +71,6 @@ include:
   # Nintendo Wii
   - project: 'libretro-infrastructure/ci-templates'
     file: '/wii-static.yml'
-
-  # Nintendo WiiU
-  - project: 'libretro-infrastructure/ci-templates'
-    file: '/wiiu-static.yml'
 
   # Nintendo Switch
   - project: 'libretro-infrastructure/ci-templates'
@@ -193,12 +184,6 @@ libretro-build-tvos-arm64:
     - .core-defs
 
 ################################### CONSOLES #################################
-# PlayStation Portable
-libretro-build-psp:
-  extends:
-    - .libretro-psp-static-retroarch-master
-    - .core-defs
-
 # PlayStation Vita
 libretro-build-vita:
   extends:
@@ -227,12 +212,6 @@ libretro-build-ngc:
 libretro-build-wii:
   extends:
     - .libretro-wii-static-retroarch-master
-    - .core-defs
-
-# Nintendo WiiU
-libretro-build-wiiu:
-  extends:
-    - .libretro-wiiu-static-retroarch-master
     - .core-defs
 
 # Nintendo Switch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -52,6 +52,39 @@ include:
     file: '/ios9.yml'
 
   ################################## CONSOLES ################################
+
+  # PlayStation Portable
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/psp-static.yml'
+
+  # PlayStation Vita
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/vita-static.yml'
+
+  # PlayStation2
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ps2-static.yml'
+
+  # Nintendo 3DS
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ctr-static.yml'
+
+  # Nintendo GameCube
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/ngc-static.yml'
+
+  # Nintendo Wii
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/wii-static.yml'
+
+  # Nintendo WiiU
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/wiiu-static.yml'
+
+  # Nintendo Switch
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/libnx-static.yml'
+
   # OpenDingux
   - project: 'libretro-infrastructure/ci-templates'
     file: '/dingux-mips32.yml'
@@ -160,6 +193,55 @@ libretro-build-tvos-arm64:
     - .core-defs
 
 ################################### CONSOLES #################################
+# PlayStation Portable
+libretro-build-psp:
+  extends:
+    - .libretro-psp-static-retroarch-master
+    - .core-defs
+
+# PlayStation Vita
+libretro-build-vita:
+  extends:
+    - .libretro-vita-static-retroarch-master
+    - .core-defs
+
+# PlayStation2
+libretro-build-ps2:
+  extends:
+    - .libretro-ps2-static-retroarch-master
+    - .core-defs
+
+# Nintendo 3DS
+libretro-build-ctr:
+  extends:
+    - .libretro-ctr-static-retroarch-master
+    - .core-defs
+
+# Nintendo GameCube
+libretro-build-ngc:
+  extends:
+    - .libretro-ngc-static-retroarch-master
+    - .core-defs
+
+# Nintendo Wii
+libretro-build-wii:
+  extends:
+    - .libretro-wii-static-retroarch-master
+    - .core-defs
+
+# Nintendo WiiU
+libretro-build-wiiu:
+  extends:
+    - .libretro-wiiu-static-retroarch-master
+    - .core-defs
+
+# Nintendo Switch
+libretro-build-libnx-aarch64:
+  extends:
+    - .libretro-libnx-static-retroarch-master
+    - .core-defs
+
+
 # OpenDingux Beta
 libretro-build-dingux-odbeta-mips32:
   extends:

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -250,7 +250,7 @@ else ifeq ($(platform), ps2)
    CC = mips64r5900el-ps2-elf-gcc$(EXE_EXT)
    CXX = mips64r5900el-ps2-elf-g++$(EXE_EXT)
    AR = mips64r5900el-ps2-elf-ar$(EXE_EXT)
-   PLATFORM_DEFINES := -DPS2 -DVIDEO_ABGR1555
+   PLATFORM_DEFINES := -DPS2 -DVIDEO_ABGR1555 -DIOAPI_NO_64
    CFLAGS += -G0
    CXXFLAGS += -G0
    STATIC_LINKING = 1
@@ -263,7 +263,7 @@ else ifeq ($(platform), psp1)
    CC = psp-gcc$(EXE_EXT)
    CXX = psp-g++$(EXE_EXT)
    AR = psp-ar$(EXE_EXT)
-   PLATFORM_DEFINES := -DPSP
+   PLATFORM_DEFINES := -DPSP -DIOAPI_NO_64
    CFLAGS += -G0
    CXXFLAGS += -G0
    STATIC_LINKING = 1
@@ -274,7 +274,7 @@ else ifeq ($(platform), vita)
    CC = arm-vita-eabi-gcc$(EXE_EXT)
    CXX = arm-vita-eabi-g++$(EXE_EXT)
    AR = arm-vita-eabi-ar$(EXE_EXT)
-   CFLAGS += -DVITA
+   CFLAGS += -DVITA -DIOAPI_NO_64
    CXXFLAGS += -DVITA
    STATIC_LINKING = 1
 
@@ -284,7 +284,7 @@ else ifeq ($(platform), ctr)
    CC = $(DEVKITARM)/bin/arm-none-eabi-gcc$(EXE_EXT)
    CXX = $(DEVKITARM)/bin/arm-none-eabi-g++$(EXE_EXT)
    AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
-   PLATFORM_DEFINES := -DARM11 -D_3DS
+   PLATFORM_DEFINES := -DARM11 -D_3DS -DIOAPI_NO_64
    CFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard
    CFLAGS += -Wall -mword-relocations
    CFLAGS += -fomit-frame-pointer -ffast-math
@@ -318,7 +318,7 @@ else ifneq (,$(filter $(platform), ngc wii wiiu))
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)
    CXX = $(DEVKITPPC)/bin/powerpc-eabi-g++$(EXE_EXT)
    AR = $(DEVKITPPC)/bin/powerpc-eabi-ar$(EXE_EXT)
-   PLATFORM_DEFINES += -DGEKKO -mcpu=750 -meabi -mhard-float
+   PLATFORM_DEFINES += -DGEKKO -mcpu=750 -meabi -mhard-float -DIOAPI_NO_64
    PLATFORM_DEFINES += -ffunction-sections -fdata-sections -D__wiiu__ -D__wut__
    STATIC_LINKING = 1
 
@@ -352,7 +352,7 @@ else ifeq ($(platform), libnx)
                 -O2 \
             -fPIE -I$(LIBNX)/include/ -ffunction-sections -fdata-sections -ftls-model=local-exec -Wl,--allow-multiple-definition -specs=$(LIBNX)/switch.specs
     CFLAGS += $(INCDIRS)
-    CFLAGS  += $(INCLUDE)  -D__SWITCH__ -DHAVE_LIBNX
+    CFLAGS  += $(INCLUDE)  -D__SWITCH__ -DHAVE_LIBNX -DIOAPI_NO_64
     CXXFLAGS += $(ASFLAGS) $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
     CFLAGS += -std=gnu11
     STATIC_LINKING = 1


### PR DESCRIPTION
Tell minizip to use 32-bit API on most statically-linked consoles.