### PR TITLE
Watchdog timer, so we recover from Space Race coin input.

### DIFF
--- a/circuit.cpp
+++ b/circuit.cpp
@@ -457,6 +457,13 @@ void Circuit::run(int64_t run_time)
 {
     while(run_time > 0)
 	{        
+      // Infinite-loop watchdog, since our libretro setup doesn't check inputs
+      // as continuously as the standalone version.
+      if (rtc.get_usecs() > last_input_update_timestamp + RETRO_WATCHDOG_USECS)
+      {
+         log_cb(RETRO_LOG_WARN, "Watchdog skipping simulation, too long since input check.\n");
+         return;
+      }
         if(queue_size)
         {
             run_time -= queue[1].time - global_time;

--- a/circuit.h
+++ b/circuit.h
@@ -14,6 +14,7 @@
 #include "chips/input.h"
 
 #define MAX_QUEUE_SIZE 4096
+#define RETRO_WATCHDOG_USECS 2000000
 
 class CircuitDesc;
 
@@ -37,6 +38,7 @@ public:
     Video& video;
     Audio audio;
     RealTimeClock rtc;
+    uint64_t last_input_update_timestamp;
    
     int queue_size;
     QueueEntry queue[MAX_QUEUE_SIZE]; // TODO: Replace with vector?

--- a/dice.cpp
+++ b/dice.cpp
@@ -75,8 +75,10 @@ void DICE::run(void)
     if(circuit)
     {
        // Run until we've got a full video frame, but not much more.
-       while (!circuit->video.frame_done) {
-            // circuit->run(2.5e-3 / Circuit::timescale); // Run 2.5 ms
+       while (!circuit->video.frame_done && 
+             // Bail if it's taken 2+ wall clock seconds since the last input check / video
+             // frame.
+             circuit->rtc.get_usecs() < circuit->last_input_update_timestamp + RETRO_WATCHDOG_USECS) {
           circuit->run(1.0e-3 / Circuit::timescale); // Run 1 ms
        }
        circuit->video.frame_done = false;
@@ -103,6 +105,8 @@ void DICE::update_input(int32_t input_state[], int32_t input_analog_left_x[], in
          circuit->input.input_pointer_x[i] = input_pointer_x[i];
          circuit->input.input_pointer_y[i] = input_pointer_y[i];
       }
+
+      circuit->last_input_update_timestamp = circuit->rtc.get_usecs();
    }
 }
 


### PR DESCRIPTION
Standalone DICE seems to update inputs more continuously; if we've spun for 2+ seconds of wall clock, take a break on simulation to trigger an input check.

Primarily an issue for Space Race's Coin input, which freezes the game until released.