### PR TITLE
libretro: fix ftello/fseeko undeclared on android

### DIFF
--- a/unzip/ioapi.c
+++ b/unzip/ioapi.c
@@ -25,6 +25,23 @@
 #define FSEEKO_FUNC(stream, offset, origin) fseeko64(stream, offset, origin)
 #endif
 
+#ifdef __ANDROID__
+#ifndef fopen64
+#define fopen64 fopen
+#endif
+#ifndef ftello
+#define ftello ftell
+#endif
+#ifndef fseeko
+#define fseeko fseek
+#endif
+#ifndef ftello64
+#define ftello64 ftell
+#endif
+#ifndef fseeko64
+#define fseeko64 fseek
+#endif
+#endif
 
 #include "ioapi.h"
 

--- a/unzip/ioapi.h
+++ b/unzip/ioapi.h
@@ -33,8 +33,8 @@
 	#ifndef _LARGEFILE64_SOURCE
 		#define _LARGEFILE64_SOURCE
 	#endif
-	#ifndef _FILE_OFFSET_BIT
-		#define _FILE_OFFSET_BIT 64
+	#ifndef _FILE_OFFSET_BITS
+		#define _FILE_OFFSET_BITS 64
 	#endif
 #endif
 


### PR DESCRIPTION
On Android 29 NDK:

```
[arm64-v8a] Compile        : retro <= ioapi.c
/builds/libretro/dice-libretro/libretro/jni/../../unzip/ioapi.c:157:11: error: call to undeclared function 'ftello'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  157 |     ret = FTELLO_FUNC((FILE *)stream);
      |           ^
/builds/libretro/dice-libretro/libretro/jni/../../unzip/ioapi.c:20:29: note: expanded from macro 'FTELLO_FUNC'
   20 | #define FTELLO_FUNC(stream) ftello(stream)
      |                             ^
/builds/libretro/dice-libretro/libretro/jni/../../unzip/ioapi.c:157:11: note: did you mean 'ftell'?
/builds/libretro/dice-libretro/libretro/jni/../../unzip/ioapi.c:20:29: note: expanded from macro 'FTELLO_FUNC'
   20 | #define FTELLO_FUNC(stream) ftello(stream)
      |                             ^
/opt/android-sdk-linux/ndk/29.0.14206865/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/stdio.h:208:18: note: 'ftell' declared here
  208 | __nodiscard long ftell(FILE* _Nonnull __fp);
      |                  ^
/builds/libretro/dice-libretro/libretro/jni/../../unzip/ioapi.c:203:8: error: call to undeclared function 'fseeko'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  203 |     if(FSEEKO_FUNC((FILE *)stream, offset, fseek_origin) != 0)
```
