### PR TITLE
ci: add a Linux aarch64 build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,6 +30,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # MacOS 64-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/osx-x64.yml'
@@ -130,6 +134,12 @@ libretro-build-linux-x64:
 libretro-build-linux-i686:
   extends:
     - .libretro-linux-i686-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # MacOS 64-bit


### PR DESCRIPTION
The libretro buildbot ships no aarch64 Linux build of DICE, so it can't be installed from RetroArch's Core Downloader on ARM64 Linux machines (ARM Chromebooks, SBCs, ARM laptops). Nothing in the core stands in the way: the `unix` branch of `Makefile.libretro` is architecture-neutral (`-fPIC -shared -Wl,-version-script`), every ARM-specific branch in that file is a 32-bit one (`classic_armv7_a7`, `classic_armv8_a35`, `rpi*`), and `android-arm64-v8a` plus `osx-arm64` already build these sources for ARM64.

This adds the `/linux-aarch64.yml` template and one job that mirrors the x64 one:

```yaml
libretro-build-linux-aarch64:
  extends:
    - .libretro-linux-aarch64-make-default
    - .core-defs
```

`.core-defs` stays last in `extends`, as in the existing Linux jobs, so `MAKEFILE`/`CORENAME` keep their values.

Verified on aarch64 (postmarketOS, glibc, GCC 15): `make platform=unix` builds clean with no source changes, and the resulting `dice_libretro.so` (ELF 64-bit ARM aarch64) runs `dummy_files/pong.dmy` at **60.4 fps, 640x246 — 100% of realtime**, measured by driving the core through a minimal libretro host (dlopen + `retro_load_game` + timed `retro_run` loop, with `info->data = NULL` like a `need_fullpath` frontend). `retro_load_game` takes 0.01 s and the per-frame environment traffic is unremarkable (`GET_VARIABLE_UPDATE` once per frame, two `SET_GEOMETRY` calls in total).

One thing I could not complete, in case it rings a bell: on that same machine the core does not get to its first frame under RetroArch itself (flatpak RetroArch 1.22.2). RA logs the core's `SET_ROTATION` and `SET_GEOMETRY`, then never reaches its own `[Core] Geometry:` line and stops answering its network command interface; disabling audio makes no difference. Since the identical binary runs at full speed through the plain libretro API on the same machine, this doesn't look architecture-related, so I've left it out of scope for this PR — happy to dig further if it isn't already known.
